### PR TITLE
Add parallel DOS example

### DIFF
--- a/docs/src/bs.md
+++ b/docs/src/bs.md
@@ -8,3 +8,46 @@ HopTB.BandStructure.getjdos
 HopTB.BandStructure.clteig
 HopTB.BandStructure.get_fermi_surfaces
 ```
+
+## Parallel DOS calculation
+
+`getdos` distributes the $k$-point mesh across all active Julia workers using the `Distributed` module. Launch Julia with multiple processes (e.g. `julia -p 4`) or add workers via `Distributed.addprocs` before calling `getdos`.
+
+The following script `examples/mydos_script.jl` computes the DOS of the sample boron nitride model in parallel and saves it to `dos.dat`:
+
+```julia
+using Distributed
+if nworkers() == 1
+    addprocs()
+end
+
+using HopTB
+
+# model and parameters
+tm = HopTB.Zoo.getBN()
+ωs = -5:0.01:5
+nkmesh = [50, 50, 1]
+
+dos = HopTB.BandStructure.getdos(tm, ωs, nkmesh; ϵ=0.1)
+
+open("dos.dat", "w") do io
+    for (ω, d) in zip(ωs, dos)
+        println(io, "$(ω) $(d)")
+    end
+end
+```
+
+To run this script on a Slurm cluster you can use an `sbatch` file similar to
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=dos
+#SBATCH --nodes=1
+#SBATCH --ntasks=4
+#SBATCH --time=01:00:00
+
+module load julia
+julia -p $SLURM_NTASKS examples/mydos_script.jl
+```
+
+`getdos` will automatically use all `$SLURM_NTASKS` processes.

--- a/examples/mydos_script.jl
+++ b/examples/mydos_script.jl
@@ -1,0 +1,27 @@
+using Distributed
+# Launch additional worker processes if not provided via `-p`.
+if nworkers() == 1
+    addprocs()
+end
+
+using HopTB
+
+# Example tight-binding model (boron nitride)
+tm = HopTB.Zoo.getBN()
+
+# Energy grid for DOS
+ωs = -5:0.01:5
+
+# Mesh size in k space
+nkmesh = [50, 50, 1]
+
+# Compute DOS using all available workers
+println("Computing DOS on $(nworkers()) workers ...")
+dos = HopTB.BandStructure.getdos(tm, ωs, nkmesh; ϵ=0.1)
+
+# Save results
+open("dos.dat", "w") do io
+    for (ω, d) in zip(ωs, dos)
+        println(io, "$(ω) $(d)")
+    end
+end


### PR DESCRIPTION
## Summary
- document how to run `getdos` in parallel
- add an example script `mydos_script.jl` for multi-process DOS calculation

## Testing
- `julia -e 'using Pkg; Pkg.test()'` *(fails: `command not found: julia`)*

------
https://chatgpt.com/codex/tasks/task_e_6889451617a48324b4bc22859c3b769f